### PR TITLE
Fix: Adds support for Visua11y's 'no animations' option (fixes #4)

### DIFF
--- a/example.json
+++ b/example.json
@@ -1,14 +1,32 @@
-    // course.json
-    {
-        "_graphicVideo": {
-            "_isEnabled": true,
-            "_fileExtension": "mp4",
-            "_loops": true,
-            "_autoPlay": true,
-            "_onScreenPercentInviewVertical": 1,
-            "_offScreenPause": true,
-            "_offScreenRewind": true,
-            "_showPauseControl": false,
-            "_onPauseRewind": false
-        }
+// course.json
+{
+    "_graphicVideo": {
+        "_isEnabled": true,
+        "_fileExtension": "mp4",
+        "_loops": true,
+        "_autoPlay": true,
+        "_onScreenPercentInviewVertical": 1,
+        "_offScreenPause": true,
+        "_offScreenRewind": true,
+        "_showPauseControl": false,
+        "_onPauseRewind": false
     }
+}
+
+// components.json - Example using a video file in a Graphic component
+{
+    "_id": "c-05",
+    "_parentId": "b-05",
+    "_type": "component",
+    "_component": "graphic",
+    "_classes": "",
+    "_layout": "left",
+    "title": "Graphic component",
+    "displayTitle": "",
+    "body": "",
+    "instruction": "",
+    "_graphic": {
+        "large": "course/en/video/media.mp4",
+        "small": "course/en/video/media.mp4"
+    }
+}

--- a/js/VideoView.js
+++ b/js/VideoView.js
@@ -130,7 +130,8 @@ export default class VideoView extends Backbone.View {
   update() {
     this.$player.toggleClass('is-graphicvideo-playing', !this.video.paused);
     this.$player.toggleClass('is-graphicvideo-paused', this.video.paused);
-    a11y.toggleEnabled(this.$player.find('.graphicvideo__rewind'), this.video.currentTime !== 0);
+    const isNotAtStart = (this.video.currentTime !== 0);
+    a11y.toggleEnabled(this.$player.find('.graphicvideo__rewind'), isNotAtStart);
   }
 
   render() {

--- a/js/VideoView.js
+++ b/js/VideoView.js
@@ -91,7 +91,7 @@ export default class VideoView extends Backbone.View {
     this.update();
   }
 
-  goToEndAndStop() {
+  rewindAndStop() {
     this.rewind();
     this.pause();
     this.video.loop = false;
@@ -173,8 +173,7 @@ export default class VideoView extends Backbone.View {
     const htmlClasses = document.documentElement.classList;
     if (!htmlClasses.contains('a11y-no-animations')) return;
 
-    // Stop on last frame
-    this.goToEndAndStop();
+    this.rewindAndStop();
   }
 
   get shouldRender() {

--- a/js/VideoView.js
+++ b/js/VideoView.js
@@ -20,23 +20,27 @@ export default class VideoView extends Backbone.View {
     this.hasUserPaused = false;
     this.isPausedWithVisua11y = this.hasA11yNoAnimations;
     this.isDataReady = false;
-    this.checkOriginalValues();
+    this.setUpOriginalValues();
+    this.resetToOriginalValues();
     this.setUpAttributeChangeObserver();
     this.setUpListeners();
     this.render();
   }
 
-  checkOriginalValues() {
+  setUpOriginalValues() {
     if (this.config._originalLoops === undefined) {
       this.config._originalLoops = this.config._loops;
     }
     if (this.config._originalAutoPlay === undefined) {
       this.config._originalAutoPlay = this.config._autoPlay;
     }
-    if (!this.isPausedWithVisua11y) {
-      this.config._loops = this.config._originalLoops;
-      this.config._autoPlay = this.config._originalAutoPlay;
-    }
+  }
+
+  resetToOriginalValues() {
+    if (this.isPausedWithVisua11y) { return; }
+
+    this.config._loops = this.config._originalLoops;
+    this.config._autoPlay = this.config._originalAutoPlay;
   }
 
   setUpAttributeChangeObserver() {

--- a/js/VideoView.js
+++ b/js/VideoView.js
@@ -13,7 +13,7 @@ export default class VideoView extends Backbone.View {
   }
 
   initialize() {
-    _.bindAll(this, 'render', 'onScreenChange', 'update', 'onDataReady', 'checkVisua11y');
+    _.bindAll(this, 'render', 'onScreenChange', 'update', 'onDataReady');
     this.config = Adapt.course.get('_graphicVideo');
     const fileExtension = this.config._fileExtension || 'mp4';
     this._rex = new RegExp(`\\.${fileExtension}`, 'i');

--- a/js/VideoView.js
+++ b/js/VideoView.js
@@ -32,7 +32,7 @@ export default class VideoView extends Backbone.View {
   setUpListeners() {
     this.$el.on('onscreen', this.onScreenChange);
     this.listenTo(Adapt, 'device:resize', this.render);
-    documentModifications.on('changed:html', this.checkVisua11y);
+    this.listenTo(documentModifications, 'changed:html', this.checkVisua11y);
   }
 
   onScreenChange(event, { onscreen, percentInview } = {}) {

--- a/js/adapt-graphicVideo.js
+++ b/js/adapt-graphicVideo.js
@@ -1,4 +1,5 @@
 import Adapt from 'core/js/adapt';
+import wait from 'core/js/wait';
 import { DOMModifier } from './injector';
 import VideoView from './VideoView';
 
@@ -45,14 +46,14 @@ class GraphicVideo extends Backbone.Controller {
           id: img.id
         });
         if (waitFor === 0) {
-          Adapt.wait.begin();
+          wait.begin();
         }
         waitFor++;
         div.videoView = new VideoView({ el: div });
         div.videoView.on('ready', () => {
           waitFor--;
           if (waitFor === 0) {
-            Adapt.wait.end();
+            wait.end();
           }
         });
       },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "git://github.com/cgkineo/adapt-graphicVideo.git"
   },
   "version": "1.0.0",
-  "framework": ">=5.14",
+  "framework": ">=5.31.27",
   "homepage": "https://github.com/cgkineo/adapt-graphicVideo",
   "issues": "https://github.com/cgkineo/adapt-graphicVideo/issues",
   "extension": "graphicVideo",


### PR DESCRIPTION
Fixes #4 

### Fix
* Adds support for Visua11y's "no animations" option. Requires framework **v5.31.27** due to the DOM Element Modification API dependency
* Added a real world example to _example.json_

### Notes
Although the original ticket requested that the video stop on the _end_ frame, I felt it might be safer if we stop on the _first_ frame in case the video was large and hadn't fully loaded.

Alternatively, we could add support for a poster image and show that instead. I'm not sure how complicated that would get, though.